### PR TITLE
🐛メンバー詳細コーディングデザイン修正

### DIFF
--- a/assets/scss/layout/layout.scss
+++ b/assets/scss/layout/layout.scss
@@ -4,7 +4,7 @@
   width: 100%;
   max-width: 980px;
   height: 100%;
-  padding: 0 15px;
+  padding: 0 20px;
   margin: 0 auto;
 }
 

--- a/documents/data/member.yml
+++ b/documents/data/member.yml
@@ -16,7 +16,7 @@ member:
             - date : "2020:04"
               img: /image/timeline/img_timeline01@2x.png
               title: Vueを使用したコーディング案件
-              work: マッチングアプリサービス
+              work: 「マッチングアプリサービス」
               part: TOPページコーディング
               body: 主にコーディングを担当。この案件でVue.jsを使ったコーディング方法を学びました。主にコーディングを担当。この案件でVue.jsを使ったコーディング方法を学びました。ああああああああああああ
             - date : "2020:04"

--- a/pages/member/-cHero.vue
+++ b/pages/member/-cHero.vue
@@ -62,6 +62,7 @@ export default {}
     font-size: 1.8rem;
 
     @include mobile {
+      font-size: 1.6rem;
       line-height: 2;
     }
   }

--- a/pages/member/-cInterview.vue
+++ b/pages/member/-cInterview.vue
@@ -71,20 +71,28 @@ export default {
     }
   }
 
+  &__number {
+    line-height: 5.4rem;
+
+    @include mobile {
+      line-height: 4rem;
+    }
+  }
+
   &__numberBox {
     @include text-white;
 
     width: 5.4rem;
-    max-height: 5.4rem;
-    padding: 1.5rem 0;
+    height: 5.4rem;
     margin-right: 4.5rem;
     text-align: center;
     background-color: $clr-primary;
 
     @include mobile {
-      min-width: 5rem;
-      min-height: 5rem;
-      margin-right: 0.9rem;
+      width: 4rem;
+      min-width: 4rem;
+      max-height: 4rem;
+      margin-right: 1.5rem;
     }
   }
 

--- a/pages/member/-cOther.vue
+++ b/pages/member/-cOther.vue
@@ -63,6 +63,10 @@ export default {
     flex-wrap: wrap;
     justify-content: center;
     margin-top: 4.5rem;
+
+    @include mobile {
+      margin-top: 3rem;
+    }
   }
 
   &__img {
@@ -73,6 +77,7 @@ export default {
 
     @include mobile {
       width: 12rem;
+      height: 12rem;
     }
   }
 

--- a/pages/member/-cProfile.vue
+++ b/pages/member/-cProfile.vue
@@ -16,7 +16,7 @@
           </div>
           <div class="c-profile__info">
             <p class="c-profile__job">
-              {{ profile.job }}
+              {{ profile.position }}
             </p>
           </div>
           <div class="c-profile__info">
@@ -49,7 +49,7 @@ export default {
 
   @include mobile {
     padding-top: 4.5rem;
-    padding-bottom: 13.4rem;
+    padding-bottom: 5rem;
   }
 
   &__box {
@@ -98,22 +98,27 @@ export default {
       font-size: 2.5rem;
 
       &::before {
-        width: 0.7rem;
+        width: 1rem;
         height: 2.3rem;
       }
     }
   }
 
   &__name--small {
+    position: absolute;
+    right: 0;
+    bottom: 7px;
     font-size: 1.6rem;
+    letter-spacing: 0;
 
     @include mobile {
-      font-size: 1.4rem;
+      font-size: 1.2rem;
     }
   }
 
   &__job {
     margin-top: 1.4rem;
+    font-size: 1.6rem;
     font-weight: bold;
   }
 

--- a/pages/member/-cTimeline.vue
+++ b/pages/member/-cTimeline.vue
@@ -113,12 +113,24 @@ export default {
   }
 
   &__start {
+    position: relative;
     z-index: 1;
-    display: inline-block;
-    width: 3.8rem;
-    height: 3.8rem;
-    background-color: #f7dfdf;
-    border-radius: 8.3rem;
+    width: 14.2rem;
+    height: 14.2rem;
+
+    &::before {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      display: inline-block;
+      width: 3.8rem;
+      height: 3.8rem;
+      content: "";
+      background-color: #f7dfdf;
+      border-radius: 8.3rem;
+      transform: translateY(-50%);
+      transform: translateX(-50%);
+    }
 
     @include mobile {
       display: none;

--- a/pages/member/-cTimeline.vue
+++ b/pages/member/-cTimeline.vue
@@ -131,7 +131,7 @@ export default {
 
     &::before {
       position: absolute;
-      top: -17.5rem;
+      top: -17rem;
       left: 6.5rem;
       z-index: -3;
       display: inline-block;

--- a/pages/member/-cTimeline.vue
+++ b/pages/member/-cTimeline.vue
@@ -63,7 +63,7 @@ export default {
   background-color: #faf7f7;
 
   @include mobile {
-    padding-top: 4rem;
+    padding-top: 5rem;
     padding-bottom: 10.3rem;
   }
 
@@ -140,6 +140,20 @@ export default {
       content: "";
       background-color: #f7dfdf;
     }
+
+    &::after {
+      position: absolute;
+      top: -1.2rem;
+      left: -1.2rem;
+      display: block;
+      width: 16.6rem;
+      height: 16.6rem;
+      content: "";
+      background: #fff 0% 0% no-repeat padding-box;
+      border: 0.3rem solid #f7dfdf;
+      border-radius: 8.3rem;
+      opacity: 1;
+    }
   }
 
   &__date {
@@ -156,6 +170,7 @@ export default {
     z-index: 3;
     width: 56.4rem;
     padding: 1.5rem 4rem;
+    margin-top: 0.6rem;
     background-color: #fff;
     border: 0.4rem solid #f7dfdf;
     border-radius: 0.5rem;
@@ -188,6 +203,12 @@ export default {
     margin-right: 1rem;
     font-weight: bold;
 
+    @include mobile {
+      font-size: 1.4rem;
+    }
+  }
+
+  &__work {
     @include mobile {
       font-size: 1.4rem;
     }


### PR DESCRIPTION
close #31 
メンバー詳細ページのデザインを修正しました。

## 修正箇所

### hero
SP
- [x] 「株式会社chatboxのメンバー紹介ページです。」のフォントサイズを16pxに変更
- [x] 左右のpaddingを15pxから20pxに変更



### プロフィール
PC
- [x] 名前の下に役職名(フロントエンジニア)を16pxで表記する

SP
- [x] 左右のpaddingを15pxから20pxに変更
- [x] 名前の左側の赤い四角のwidthを10pxに変更
- [x] 名前の英語表記を12pxに変更
- [x] 名前の英語表記のletter-spacingを0にする
- [x] 名前の英語表記を右端に寄せる
- [x] 名前の下に役職名(フロントエンジニア)を16pxで表記する
- [x] 自己紹介テキストから実績タイムラインセクションまでの幅を50pxにする


### 実績タイムライン
SP
- [x] 左右のpaddingを15pxから20pxに変更
- [x] h2の上部paddingを50pxに変更
- [x] 案件内容を14pxにして画像のように案件内容名(マッチングサービスアプリの部分)を「」でかこむ

PC/SP
- [x] 実績画像の背景にwidth166px、height166pxの#f7dfdfで3ox縁取りされた白い丸を配置
<img width="391" alt="スクリーンショット 2020-04-27 17 35 23" src="https://user-images.githubusercontent.com/58157082/80351541-7b71d980-88ad-11ea-9fdf-a6ca047d2fd2.png">




### ミニインタビュー

SP
- [x] 左右のpaddingを15pxから20pxに変更
- [x] 数字のボックスをwidth40px、height 40pxに変更
- [x] 数字のボックスの右のmarginを15pxに変更



### 他のメンバー
- [x] 左右のpaddingを15pxから20pxに変更
- [x] 顔写真アイコンサイズをwidth 120px、height 120pxに変更
